### PR TITLE
Add @policy directive support

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_BUILD__JARO_WINKLER: "--with-cflags=-Wno-error=incompatible-function-pointer-types"
+BUNDLE_BUILD__DEBASE: "--with-cflags=-Wno-error=incompatible-function-pointer-types"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 .circleci/processed-config.yml
 
 .DS_Store
+
+/.idea

--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,47 @@
+*.gem
+*.rbc
+.idea
+coverage
+InstalledFiles
+pkg
+spec/reports
+spec/examples.txt
+test/tmp
+test/version_tmp
+tmp
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build
+*.bridgesupport
+build-iPhoneOS
+build-iPhoneSimulator
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+.yardoc
+_yardoc
+
+## Environment normalization:
+vendor/bundle
+lib/bundler/man
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,7 @@ GEM
     debase-ruby_core_source (3.2.0)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    google-protobuf (3.22.2-arm64-darwin)
-    google-protobuf (3.22.2-x86_64-darwin)
-    google-protobuf (3.22.2-x86_64-linux)
+    google-protobuf (3.22.2)
     graphql (2.0.19)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -58,7 +56,11 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.7)
     minitest (5.18.0)
+    nokogiri (1.14.2)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
@@ -119,6 +121,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  ruby
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/README.md
+++ b/README.md
@@ -302,6 +302,20 @@ class User < BaseObject
 end
 ```
 
+### The `@policy` directive (Apollo Federation v2)
+
+[Apollo documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#policy)
+
+Call `policy` within your class definition or pass the `policy:` option to your field definition:
+
+```ruby
+class Product < BaseObject
+  policy policies: [["stock:read"]]
+  field :id, ID, null: false
+  field :inStock, Boolean, null: false, policy: { policies: [["stock:read"]] }
+end
+```
+
 ### Field set syntax
 
 Field sets can be either strings encoded with the Apollo Field Set [syntax]((https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#scalar-_fieldset)) or arrays, hashes and snake case symbols that follow the graphql-ruby conventions:

--- a/lib/apollo-federation/enum.rb
+++ b/lib/apollo-federation/enum.rb
@@ -18,6 +18,16 @@ module ApolloFederation
       def inaccessible
         add_directive(name: 'inaccessible')
       end
+
+      def policy(policies)
+        add_directive(
+          name: "policy",
+          arguments: [
+            name: 'policies',
+            values: policies,
+          ]
+        )
+      end
     end
   end
 end

--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -8,7 +8,7 @@ module ApolloFederation
     include HasDirectives
 
     VERSION_1_DIRECTIVES = %i[external requires provides].freeze
-    VERSION_2_DIRECTIVES = %i[shareable inaccessible override tags].freeze
+    VERSION_2_DIRECTIVES = %i[shareable inaccessible override policy tags].freeze
 
     def initialize(*args, **kwargs, &block)
       add_v1_directives(**kwargs)
@@ -59,7 +59,7 @@ module ApolloFederation
       nil
     end
 
-    def add_v2_directives(shareable: nil, inaccessible: nil, override: nil, tags: [], **_kwargs)
+    def add_v2_directives(shareable: nil, inaccessible: nil, override: nil, tags: [], policy: nil, **_kwargs)
       if shareable
         add_directive(name: 'shareable')
       end
@@ -75,6 +75,16 @@ module ApolloFederation
             name: 'from',
             values: override[:from],
           ],
+        )
+      end
+
+      if policy
+        add_directive(
+          name: "policy",
+          arguments: [
+            name: 'policies',
+            values: policy[:policies]
+          ]
         )
       end
 

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -26,6 +26,16 @@ module ApolloFederation
         add_directive(name: 'tag', arguments: [name: 'name', values: name])
       end
 
+      def policy(policies)
+        add_directive(
+          name: "policy",
+          arguments: [
+            name: 'policies',
+            values: policies,
+          ]
+        )
+      end
+
       def key(fields:, camelize: true)
         add_directive(
           name: 'key',

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -32,6 +32,16 @@ module ApolloFederation
         add_directive(name: 'tag', arguments: [name: 'name', values: name])
       end
 
+      def policy(policies)
+        add_directive(
+          name: "policy",
+          arguments: [
+            name: 'policies',
+            values: policies,
+          ]
+        )
+      end
+
       def key(fields:, camelize: true, resolvable: true)
         arguments = [
           name: 'fields',

--- a/lib/apollo-federation/scalar.rb
+++ b/lib/apollo-federation/scalar.rb
@@ -18,6 +18,16 @@ module ApolloFederation
       def inaccessible
         add_directive(name: 'inaccessible')
       end
+
+      def policy(policies)
+        add_directive(
+          name: "policy",
+          arguments: [
+            name: 'policies',
+            values: policies,
+          ]
+        )
+      end
     end
   end
 end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,7 +7,7 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = ['inaccessible', 'tag'].freeze
+    IMPORTED_DIRECTIVES = ['inaccessible', 'tag', 'policy'].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)
@@ -64,7 +64,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(IMPORTED_DIRECTIVES.map { |directive| "\"@#{directive}\"" }).join(', ')}])
+            @link(url: "https://specs.apollo.dev/federation/v#{federation_version}"#{federation_namespace}, import: [#{(IMPORTED_DIRECTIVES.map { |directive| "\"@#{directive}\"" }).join(', ')}])
 
         SCHEMA
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,7 +7,7 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = ['inaccessible', 'tag', 'policy'].freeze
+    IMPORTED_DIRECTIVES = ['inaccessible', 'policy', 'tag'].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)

--- a/spec/apollo-federation/schema_spec.rb
+++ b/spec/apollo-federation/schema_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe ApolloFederation::Schema do
       expect(schema.federation_version).to eq('1.0')
     end
 
-    it 'returns the specified version when set to 2.0' do
+    it 'returns the specified version when set to 2.6' do
       schema = Class.new(GraphQL::Schema) do
         include ApolloFederation::Schema
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
-      expect(schema.federation_version).to eq('2.0')
+      expect(schema.federation_version).to eq('2.6')
     end
 
     it 'returns the specified version when set to 2.3' do

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0'
+          federation version: '2.6'
         end
 
         expect(schema.to_definition).to match_sdl(
@@ -109,13 +109,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             upc: String!
@@ -144,13 +144,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends {
             upc: String!
@@ -180,13 +180,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position @federation__shareable {
             x: Int!
@@ -217,13 +217,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position @inaccessible {
             x: Int!
@@ -254,13 +254,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position @tag(name: "private") {
             x: Int!
@@ -272,6 +272,43 @@ RSpec.describe ApolloFederation::ServiceField do
           }
         GRAPHQL
       )
+    end
+
+    it 'returns valid SDL for types with policy' do
+      position = Class.new(base_object) do
+        graphql_name 'Position'
+        policy [['private']]
+
+        field :x, Integer, null: false
+        field :y, Integer, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :position, position, null: true
+      end
+
+      schema = Class.new(base_schema) do
+        query query_obj
+        federation version: '2.6'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+                                       <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
+
+          type Position @policy(policies: [["private"]]) {
+            x: Int!
+            y: Int!
+          }
+
+          type Query {
+            position: Position
+          }
+        GRAPHQL
+                                     )
     end
 
     context 'with a custom link namespace provided' do
@@ -291,13 +328,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @fed2__extends {
               upc: String!
@@ -327,13 +364,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Position @fed2__shareable {
               x: Int!
@@ -364,13 +401,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Position @inaccessible {
               x: Int!
@@ -401,13 +438,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Position @tag(name: "private") {
               x: Int!
@@ -437,13 +474,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -468,13 +505,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.6', link: { as: 'fed2' }
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -501,7 +538,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -544,13 +581,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types book
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Book implements Product {
             upc: String!
@@ -596,13 +633,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types book
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Book implements Product {
             upc: String!
@@ -613,6 +650,58 @@ RSpec.describe ApolloFederation::ServiceField do
           }
         GRAPHQL
       )
+    end
+
+    it 'returns valid SDL for interface types with policy' do
+      base_field = Class.new(GraphQL::Schema::Field) do
+        include ApolloFederation::Field
+      end
+
+      base_interface = Module.new do
+        include GraphQL::Schema::Interface
+        include ApolloFederation::Interface
+
+        # graphql_name 'Interface'
+        field_class base_field
+      end
+
+      product = Module.new do
+        include base_interface
+
+        graphql_name 'Product'
+
+        policy [['private']]
+
+        field :upc, String, null: false
+      end
+
+      book = Class.new(base_object) do
+        implements product
+
+        graphql_name 'Book'
+
+        field :upc, String, null: false
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types book
+        federation version: '2.6'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+                                       <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
+
+          type Book implements Product {
+            upc: String!
+          }
+
+          interface Product @policy(policies: [["private"]]) {
+            upc: String!
+          }
+        GRAPHQL
+                                     )
     end
 
     it 'returns valid SDL for interface types' do
@@ -659,13 +748,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types book, pen
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Book implements Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -703,13 +792,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types book, product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Book {
             upc: String!
@@ -741,13 +830,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types book, product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Book {
             upc: String!
@@ -759,6 +848,43 @@ RSpec.describe ApolloFederation::ServiceField do
     end
 
     it 'returns valid SDL for tagged enum types' do
+      base_enum = Class.new(GraphQL::Schema::Enum) do
+        include ApolloFederation::Enum
+      end
+
+      product_type = Class.new(base_enum) do
+        graphql_name 'ProductType'
+        policy [['private']]
+
+        value 'BOOK'
+        value 'PEN'
+      end
+
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+
+        field :type, product_type, null: false
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types product_type, product
+        federation version: '2.6'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
+
+          enum ProductType @policy(policies: [["private"]]) {
+            BOOK
+            PEN
+          }
+        GRAPHQL
+      )
+    end
+
+    it 'returns valid SDL for enum types with policy' do
       base_enum = Class.new(GraphQL::Schema::Enum) do
         include ApolloFederation::Enum
       end
@@ -779,20 +905,20 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product_type, product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
-        <<~GRAPHQL,
+                                       <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           enum ProductType @tag(name: "private") {
             BOOK
             PEN
           }
         GRAPHQL
-      )
+                                     )
     end
 
     it 'returns valid SDL for inaccessible enum types' do
@@ -816,13 +942,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product_type, product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           enum ProductType @inaccessible {
             BOOK
@@ -857,13 +983,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             upc: UPC!
@@ -876,6 +1002,52 @@ RSpec.describe ApolloFederation::ServiceField do
           scalar UPC @tag(name: "private")
         GRAPHQL
       )
+    end
+
+    it 'returns valid SDL for scalar types with policy' do
+      base_scalar = Class.new(GraphQL::Schema::Scalar) do
+        include ApolloFederation::Scalar
+      end
+
+      upc = Class.new(base_scalar) do
+        graphql_name 'UPC'
+
+        policy [['private']]
+      end
+
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+
+        field :upc, upc, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true
+      end
+
+      schema = Class.new(base_schema) do
+        query query_obj
+        federation version: '2.6'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+                                       <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
+
+          type Product {
+            upc: UPC!
+          }
+
+          type Query {
+            product: Product
+          }
+
+          scalar UPC @policy(policies: [["private"]])
+        GRAPHQL
+                                     )
     end
 
     it 'returns valid SDL for inaccessible scalar types' do
@@ -903,13 +1075,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             upc: UPC!
@@ -953,13 +1125,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1008,13 +1180,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1063,13 +1235,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1118,13 +1290,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1167,13 +1339,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1212,13 +1384,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         mutation mutations
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1251,13 +1423,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0'
+          federation version: '2.6'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -1282,13 +1454,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.0'
+          federation version: '2.6'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -1310,13 +1482,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
             name: String
@@ -1336,13 +1508,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__key(fields: "upc", resolvable: false) {
             upc: String!
@@ -1361,13 +1533,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__key(fields: "upc") {
             upc: String!
@@ -1388,13 +1560,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -1402,6 +1574,33 @@ RSpec.describe ApolloFederation::ServiceField do
           }
         GRAPHQL
       )
+    end
+
+    it 'returns valid SDL for @policy directive' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        key fields: :id
+
+        field :id, 'ID', null: false
+        field :isStock, 'Boolean', null: false, policy: { policies: [['private']] }
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types product
+        federation version: '2.6'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+                                       <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
+
+          type Product @federation__key(fields: "id") {
+            id: ID!
+            isStock: Boolean! @policy(policies: [["private"]])
+          }
+        GRAPHQL
+                                     )
     end
 
     it 'returns valid SDL for @interfaceObject directives' do
@@ -1415,13 +1614,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.3'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
@@ -1446,13 +1645,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position {
             x: Int! @federation__shareable
@@ -1482,13 +1681,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position {
             x: Int! @inaccessible
@@ -1518,13 +1717,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position {
             x: Int! @tag(name: "private")
@@ -1554,13 +1753,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Position {
             x: Int! @tag(name: "private") @tag(name: "protected")
@@ -1606,13 +1805,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1662,13 +1861,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1718,13 +1917,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         query query_obj
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product {
             type: ProductType!
@@ -1754,13 +1953,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends @federation__key(fields: "id") {
             id: ID!
@@ -1790,13 +1989,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product, review
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -1825,13 +2024,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int @federation__external
@@ -1854,13 +2053,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.0'
+          federation version: '2.6'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @federation__key(fields: "productId") {
               productId: String!
@@ -1882,13 +2081,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.0'
+          federation version: '2.6'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
             type Product @federation__extends @federation__key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
@@ -1915,13 +2114,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
       schema = Class.new(base_schema) do
         orphan_types product
-        federation version: '2.0'
+        federation version: '2.6'
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -1942,14 +2141,14 @@ RSpec.describe ApolloFederation::ServiceField do
       end
 
       schema = Class.new(base_schema) do
-        federation version: '2.0'
+        federation version: '2.6'
         orphan_types product
       end
 
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @federation__key(fields: "id") {
             id: ID!
@@ -1973,7 +2172,7 @@ RSpec.describe ApolloFederation::ServiceField do
       end
 
       new_base_schema = Class.new(base_schema) do
-        federation version: '2.0', link: { as: 'fed2' }
+        federation version: '2.6', link: { as: 'fed2' }
       end
 
       schema = Class.new(new_base_schema) do
@@ -1983,7 +2182,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @fed2__extends {
             upc: String!
@@ -2011,7 +2210,7 @@ RSpec.describe ApolloFederation::ServiceField do
       end
 
       new_base_schema = Class.new(base_schema) do
-        federation version: '2.0', link: { as: 'fed2' }
+        federation version: '2.6', link: { as: 'fed2' }
         query query_obj
       end
 
@@ -2020,7 +2219,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@inaccessible", "@policy", "@tag"])
 
           type Product @fed2__extends {
             upc: String!


### PR DESCRIPTION
This PR adds support for the `@policy` directive. 

A required change was to bump Federation version to 2.6 - it's parametrized now.

Also, attached some required bundle config settings to be able to do `bundle install` on Apple Silicon Macs.