### PR TITLE
feat: refactor Apollo Federation schema handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# [Unreleased]
-
-### Features
-
-* add support for the `@listSize` directive
-
 # [3.11.0](https://github.com/mondaycom/apollo-federation-ruby/compare/v3.10.0...v3.11.0) (2025-06-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Features
+
+* add support for the `@listSize` directive
+
 # [3.11.0](https://github.com/mondaycom/apollo-federation-ruby/compare/v3.10.0...v3.11.0) (2025-06-17)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,9 +55,6 @@ GEM
     drb (2.2.1)
     erubi (1.13.0)
     google-protobuf (3.25.5)
-    google-protobuf (3.25.5-arm64-darwin)
-    google-protobuf (3.25.5-x86_64-darwin)
-    google-protobuf (3.25.5-x86_64-linux)
     graphql (2.0.31)
       base64
     i18n (1.14.6)

--- a/README.md
+++ b/README.md
@@ -331,6 +331,16 @@ class Product < BaseObject
 end
 ```
 
+### The `@listSize` directive (Apollo Federation v2.9)
+
+Use `list_size` to describe the expected size of list results for query planning:
+
+```ruby
+class Product < BaseObject
+  field :reviews, [String], null: false, list_size: { assumed_size: 5 }
+end
+```
+
 ### Field set syntax
 
 Field sets can be either strings encoded with the Apollo Field Set [syntax]((https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#scalar-_fieldset)) or arrays, hashes and snake case symbols that follow the graphql-ruby conventions:

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ To support [federated tracing](https://www.apollographql.com/docs/apollo-server/
 
 When using tools like [rover](https://www.apollographql.com/docs/rover/) for schema validation, etc., add a Rake task that prints the Federated SDL to a file:
 
+The generated SDL automatically imports only the federation directives that your schema uses when targeting Federation v2.
+
 ```rb
 namespace :graphql do
   namespace :federation do

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -2,6 +2,7 @@
 
 require 'graphql'
 require 'apollo-federation/service'
+require 'set'
 
 module ApolloFederation
   class FederatedDocumentFromSchemaDefinition < GraphQL::Language::DocumentFromSchemaDefinition
@@ -14,6 +15,15 @@ module ApolloFederation
       '_entities',
       '_service',
     ].freeze
+
+
+
+    attr_reader :used_directives
+
+    def initialize(*args, **kwargs)
+      super
+      @used_directives = Set.new
+    end
 
     def build_object_type_node(object_type)
       object_node = super
@@ -91,6 +101,7 @@ module ApolloFederation
       end
 
       directives.each do |directive|
+        @used_directives << directive[:name]
         node = node.merge_directive(
           name: directive_name(directive),
           arguments: build_arguments_node(directive[:arguments]),
@@ -100,7 +111,7 @@ module ApolloFederation
     end
 
     def directive_name(directive)
-      if schema.federation_2? && schema.all_links.none? { |link| link[:import]&.include?(directive[:name]) }
+      if schema.federation_2? && schema.default_link_namespace
         "#{schema.default_link_namespace}__#{directive[:name]}"
       else
         directive[:name]

--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -8,7 +8,7 @@ module ApolloFederation
     include HasDirectives
 
     VERSION_1_DIRECTIVES = %i[external requires provides].freeze
-    VERSION_2_DIRECTIVES = %i[shareable inaccessible override policy tags cost].freeze
+    VERSION_2_DIRECTIVES = %i[shareable inaccessible override policy tags cost list_size].freeze
 
     def initialize(*args, **kwargs, &block)
       add_v1_directives(**kwargs)
@@ -59,7 +59,7 @@ module ApolloFederation
       nil
     end
 
-    def add_v2_directives(shareable: nil, inaccessible: nil, override: nil, tags: [], policy: nil, cost: nil, **_kwargs)
+    def add_v2_directives(shareable: nil, inaccessible: nil, override: nil, tags: [], policy: nil, cost: nil, list_size: nil, **_kwargs)
       [{ flag: shareable, name: 'shareable' }, { flag: inaccessible, name: 'inaccessible' }].each do |directive|
         add_directive(name: directive[:name]) if directive[:flag]
       end
@@ -67,6 +67,7 @@ module ApolloFederation
       add_override_directive(override)
       add_policy_directive(policy)
       add_cost_directive(cost)
+      add_list_size_directive(list_size)
 
       tags.each { |tag| add_tag_directive(tag) }
 
@@ -107,6 +108,29 @@ module ApolloFederation
           values: cost[:weight] || 1,
         ],
       )
+    end
+
+    def add_list_size_directive(list_size)
+      return unless list_size
+
+      arguments = []
+      if list_size.key?(:assumed_size)
+        arguments << { name: 'assumedSize', values: list_size[:assumed_size] }
+      end
+      if (slicing_args = list_size[:slicing_arguments])
+        arguments << { name: 'slicingArguments', values: slicing_args }
+        if list_size.key?(:require_one_slicing_argument)
+          arguments << {
+            name: 'requireOneSlicingArgument',
+            values: list_size[:require_one_slicing_argument]
+          }
+        end
+      end
+      if list_size[:sized_fields]
+        arguments << { name: 'sizedFields', values: list_size[:sized_fields] }
+      end
+
+      add_directive(name: 'listSize', arguments: arguments) unless arguments.empty?
     end
 
     def add_tag_directive(tag)

--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -59,7 +59,9 @@ module ApolloFederation
       nil
     end
 
-    def add_v2_directives(shareable: nil, inaccessible: nil, override: nil, tags: [], policy: nil, cost: nil, list_size: nil, **_kwargs)
+    def add_v2_directives(
+      shareable: nil, inaccessible: nil, override: nil, tags: [], policy: nil, cost: nil, list_size: nil, **_kwargs
+    )
       [{ flag: shareable, name: 'shareable' }, { flag: inaccessible, name: 'inaccessible' }].each do |directive|
         add_directive(name: directive[:name]) if directive[:flag]
       end
@@ -122,7 +124,7 @@ module ApolloFederation
         if list_size.key?(:require_one_slicing_argument)
           arguments << {
             name: 'requireOneSlicingArgument',
-            values: list_size[:require_one_slicing_argument]
+            values: list_size[:require_one_slicing_argument],
           }
         end
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,7 +7,7 @@ require 'apollo-federation/federated_document_from_schema_definition'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = ['composeDirective', 'inaccessible', 'policy', 'tag', 'cost'].freeze
+    IMPORTED_DIRECTIVES = ['composeDirective', 'inaccessible', 'policy', 'tag', 'cost', 'listSize'].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -7,15 +7,11 @@ require 'apollo-federation/federated_document_from_schema_definition'
 
 module ApolloFederation
   module Schema
-    IMPORTED_DIRECTIVES = ['composeDirective', 'inaccessible', 'policy', 'tag', 'cost', 'listSize'].freeze
-
     def self.included(klass)
       klass.extend(CommonMethods)
     end
 
     module CommonMethods
-      DEFAULT_LINK_NAMESPACE = 'federation'
-
       def federation(version: '1.0', default_link_namespace: nil, links: [], compose_directives: [])
         @federation_version = version
         @default_link_namespace = default_link_namespace
@@ -35,12 +31,15 @@ module ApolloFederation
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
 
         output = GraphQL::Language::Printer.new.print(document_from_schema.document)
-        output.prepend(federation_2_prefix) if federation_2?
+        if federation_2?
+          used = document_from_schema.used_directives.to_a
+          output.prepend(federation_2_prefix(used_directives: used))
+        end
         output
       end
 
       def default_link_namespace
-        @default_link_namespace || find_inherited_value(:default_link_namespace, DEFAULT_LINK_NAMESPACE)
+        @default_link_namespace || find_inherited_value(:default_link_namespace, nil)
       end
 
       def query(new_query_object = nil)
@@ -63,13 +62,25 @@ module ApolloFederation
         @links || find_inherited_value(:links, [])
       end
 
-      def all_links
-        imported_directives = IMPORTED_DIRECTIVES
+      def all_links(used_directives: [])
+        # If custom namespace is provided, don't import any directives (use prefixed versions instead)
+        if default_link_namespace
+          imported_directives = []
+        else
+          # Collect all directives that should be imported
+          all_directives = used_directives
+          # Include @composeDirective when compose_directives are configured
+          all_directives << 'composeDirective' if compose_directives.any?
+          
+          # Remove duplicates while preserving order
+          imported_directives = all_directives.uniq
+        end
+        
         default_link = {
           url: "https://specs.apollo.dev/federation/v#{federation_version}",
           import: imported_directives,
         }
-        default_link[:as] = default_link_namespace if default_link_namespace != DEFAULT_LINK_NAMESPACE
+        default_link[:as] = default_link_namespace if default_link_namespace
         [default_link, *links]
       end
 
@@ -79,14 +90,14 @@ module ApolloFederation
         @orig_query_object || find_inherited_value(:original_query)
       end
 
-      def federation_2_prefix
+      def federation_2_prefix(used_directives: [])
         schema = ['extend schema']
 
-        all_links.each do |link|
+        all_links(used_directives: used_directives).each do |link|
           link_str = '  @link('
           link_str += "url: \"#{link[:url]}\""
           link_str += ", as: \"#{link[:as]}\"" if link[:as]
-          if link[:import]
+          if link[:import] && !link[:import].empty?
             imported_directives = link[:import].map { |d| "\"@#{d}\"" }.join(', ')
             link_str += ", import: [#{imported_directives}]"
           end

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             upc: String!
@@ -150,7 +150,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends {
             upc: String!
@@ -186,7 +186,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position @federation__shareable {
             x: Int!
@@ -223,7 +223,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position @inaccessible {
             x: Int!
@@ -260,7 +260,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position @tag(name: "private") {
             x: Int!
@@ -297,7 +297,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position @policy(policies: [["private"]]) {
             x: Int!
@@ -334,7 +334,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position @cost(weight: 5) {
             x: Int!
@@ -371,7 +371,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @fed2__extends {
               upc: String!
@@ -407,7 +407,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Position @fed2__shareable {
               x: Int!
@@ -444,7 +444,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Position @inaccessible {
               x: Int!
@@ -481,7 +481,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Position @tag(name: "private") {
               x: Int!
@@ -517,7 +517,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -548,7 +548,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -575,7 +575,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -624,7 +624,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book implements Product {
             upc: String!
@@ -676,7 +676,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book implements Product {
             upc: String!
@@ -728,7 +728,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book implements Product {
             upc: String!
@@ -791,7 +791,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book implements Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -835,7 +835,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book {
             upc: String!
@@ -873,7 +873,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Book {
             upc: String!
@@ -911,7 +911,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           enum ProductType @policy(policies: [["private"]]) {
             BOOK
@@ -948,7 +948,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           enum ProductType @tag(name: "private") {
             BOOK
@@ -985,7 +985,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           enum ProductType @cost(weight: 5) {
             BOOK
@@ -1022,7 +1022,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           enum ProductType @inaccessible {
             BOOK
@@ -1063,7 +1063,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             upc: UPC!
@@ -1109,7 +1109,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             upc: UPC!
@@ -1155,7 +1155,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             upc: UPC!
@@ -1201,7 +1201,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             upc: UPC!
@@ -1251,7 +1251,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1306,7 +1306,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1361,7 +1361,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1416,7 +1416,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1465,7 +1465,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1510,7 +1510,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1555,7 +1555,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1594,7 +1594,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -1625,7 +1625,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -1653,7 +1653,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
             name: String
@@ -1679,7 +1679,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "upc", resolvable: false) {
             upc: String!
@@ -1704,7 +1704,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "upc") {
             upc: String!
@@ -1731,7 +1731,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -1758,7 +1758,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "id") {
             id: ID!
@@ -1785,11 +1785,38 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "id") {
             id: ID!
             isStock: Boolean! @cost(weight: 5)
+          }
+        GRAPHQL
+      )
+    end
+
+    it 'returns valid SDL for @listSize directive' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        key fields: :id
+
+        field :id, 'ID', null: false
+        field :reviews, [String], null: false, list_size: { assumed_size: 5 }
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types product
+        federation version: '2.9'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+
+          type Product @federation__key(fields: "id") {
+            id: ID!
+            reviews: [String!]! @listSize(assumedSize: 5)
           }
         GRAPHQL
       )
@@ -1812,7 +1839,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
@@ -1843,7 +1870,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position {
             x: Int! @federation__shareable
@@ -1879,7 +1906,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position {
             x: Int! @inaccessible
@@ -1915,7 +1942,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position {
             x: Int! @tag(name: "private")
@@ -1951,7 +1978,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Position {
             x: Int! @tag(name: "private") @tag(name: "protected")
@@ -2003,7 +2030,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             type: ProductType!
@@ -2059,7 +2086,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             type: ProductType!
@@ -2115,7 +2142,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product {
             type: ProductType!
@@ -2151,7 +2178,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends @federation__key(fields: "id") {
             id: ID!
@@ -2187,7 +2214,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -2222,7 +2249,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int @federation__external
@@ -2251,7 +2278,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @federation__key(fields: "productId") {
               productId: String!
@@ -2279,7 +2306,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
             type Product @federation__extends @federation__key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
@@ -2312,7 +2339,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -2340,7 +2367,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @federation__key(fields: "id") {
             id: ID!
@@ -2374,7 +2401,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @fed2__extends {
             upc: String!
@@ -2411,7 +2438,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
 
           type Product @fed2__extends {
             upc: String!

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6")
 
           type Product {
             upc: String!
@@ -150,9 +150,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@extends"])
 
-          type Product @federation__extends {
+          type Product @extends {
             upc: String!
           }
 
@@ -186,9 +186,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@shareable"])
 
-          type Position @federation__shareable {
+          type Position @shareable {
             x: Int!
             y: Int!
           }
@@ -223,7 +223,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Position @inaccessible {
             x: Int!
@@ -260,7 +260,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Position @tag(name: "private") {
             x: Int!
@@ -297,7 +297,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"])
 
           type Position @policy(policies: [["private"]]) {
             x: Int!
@@ -334,7 +334,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@cost"])
 
           type Position @cost(weight: 5) {
             x: Int!
@@ -371,7 +371,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
             type Product @fed2__extends {
               upc: String!
@@ -407,7 +407,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
             type Position @fed2__shareable {
               x: Int!
@@ -444,9 +444,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
-            type Position @inaccessible {
+            type Position @fed2__inaccessible {
               x: Int!
               y: Int!
             }
@@ -481,9 +481,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
-            type Position @tag(name: "private") {
+            type Position @fed2__tag(name: "private") {
               x: Int!
               y: Int!
             }
@@ -517,7 +517,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -548,7 +548,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -575,7 +575,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -624,7 +624,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Book implements Product {
             upc: String!
@@ -676,7 +676,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Book implements Product {
             upc: String!
@@ -728,7 +728,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"])
 
           type Book implements Product {
             upc: String!
@@ -791,17 +791,17 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@external", "@extends"])
 
-          type Book implements Product @federation__extends @federation__key(fields: "upc") {
-            upc: String! @federation__external
+          type Book implements Product @extends @key(fields: "upc") {
+            upc: String! @external
           }
 
-          type Pen implements Product @federation__key(fields: "upc") {
+          type Pen implements Product @key(fields: "upc") {
             upc: String!
           }
 
-          interface Product @federation__key(fields: "upc") {
+          interface Product @key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -835,7 +835,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Book {
             upc: String!
@@ -873,7 +873,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Book {
             upc: String!
@@ -911,7 +911,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"])
 
           enum ProductType @policy(policies: [["private"]]) {
             BOOK
@@ -948,7 +948,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           enum ProductType @tag(name: "private") {
             BOOK
@@ -985,7 +985,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@cost"])
 
           enum ProductType @cost(weight: 5) {
             BOOK
@@ -1022,7 +1022,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           enum ProductType @inaccessible {
             BOOK
@@ -1063,7 +1063,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Product {
             upc: UPC!
@@ -1109,7 +1109,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy"])
 
           type Product {
             upc: UPC!
@@ -1155,7 +1155,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@cost"])
 
           type Product {
             upc: UPC!
@@ -1201,7 +1201,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Product {
             upc: UPC!
@@ -1251,7 +1251,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1306,7 +1306,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1361,7 +1361,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1416,7 +1416,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1465,7 +1465,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1510,7 +1510,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@cost"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1555,7 +1555,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           """
           Autogenerated return type of CreateProduct.
@@ -1594,9 +1594,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-            type Product @federation__key(fields: "upc") {
+            type Product @key(fields: "upc") {
               upc: String!
             }
 
@@ -1625,9 +1625,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-            type Product @federation__key(fields: "upc") {
+            type Product @key(fields: "upc") {
               upc: String!
             }
           GRAPHQL
@@ -1653,9 +1653,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-          type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
+          type Product @key(fields: "upc") @key(fields: "name") {
             name: String
             upc: String!
           }
@@ -1679,9 +1679,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-          type Product @federation__key(fields: "upc", resolvable: false) {
+          type Product @key(fields: "upc", resolvable: false) {
             upc: String!
           }
         GRAPHQL
@@ -1704,9 +1704,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-          type Product @federation__key(fields: "upc") {
+          type Product @key(fields: "upc") {
             upc: String!
           }
         GRAPHQL
@@ -1728,17 +1728,17 @@ RSpec.describe ApolloFederation::ServiceField do
         federation version: '2.6'
       end
 
-      expect(execute_sdl(schema)).to match_sdl(
-        <<~GRAPHQL,
-          extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              expect(execute_sdl(schema)).to match_sdl(
+          <<~GRAPHQL,
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@extends", "@key"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
-            price: Int
-            upc: String! @federation__external
-          }
-        GRAPHQL
-      )
+            type Product @extends @key(fields: "upc") {
+              price: Int
+              upc: String! @external
+            }
+          GRAPHQL
+        )
     end
 
     it 'returns valid SDL for @policy directive' do
@@ -1758,9 +1758,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@policy", "@key"])
 
-          type Product @federation__key(fields: "id") {
+          type Product @key(fields: "id") {
             id: ID!
             isStock: Boolean! @policy(policies: [["private"]])
           }
@@ -1785,9 +1785,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@cost", "@key"])
 
-          type Product @federation__key(fields: "id") {
+          type Product @key(fields: "id") {
             id: ID!
             isStock: Boolean! @cost(weight: 5)
           }
@@ -1812,9 +1812,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@listSize", "@key"])
 
-          type Product @federation__key(fields: "id") {
+          type Product @key(fields: "id") {
             id: ID!
             reviews: [String!]! @listSize(assumedSize: 5)
           }
@@ -1839,9 +1839,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@interfaceObject", "@key"])
 
-          type Product @federation__interfaceObject @federation__key(fields: "id") {
+          type Product @interfaceObject @key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -1870,11 +1870,11 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@shareable"])
 
           type Position {
-            x: Int! @federation__shareable
-            y: Int! @federation__shareable
+            x: Int! @shareable
+            y: Int! @shareable
           }
 
           type Query {
@@ -1906,7 +1906,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Position {
             x: Int! @inaccessible
@@ -1942,7 +1942,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Position {
             x: Int! @tag(name: "private")
@@ -1978,7 +1978,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Position {
             x: Int! @tag(name: "private") @tag(name: "protected")
@@ -2030,7 +2030,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Product {
             type: ProductType!
@@ -2086,7 +2086,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@tag"])
 
           type Product {
             type: ProductType!
@@ -2142,7 +2142,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@inaccessible"])
 
           type Product {
             type: ProductType!
@@ -2178,11 +2178,11 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@override", "@extends", "@key"])
 
-          type Product @federation__extends @federation__key(fields: "id") {
+          type Product @extends @key(fields: "id") {
             id: ID!
-            isStock: Boolean! @federation__override(from: "Products")
+            isStock: Boolean! @override(from: "Products")
           }
         GRAPHQL
       )
@@ -2214,16 +2214,16 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@provides", "@key", "@external", "@extends"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
+          type Product @extends @key(fields: "upc") {
             price: Int
-            upc: String! @federation__external
+            upc: String! @external
           }
 
-          type Review @federation__key(fields: "id") {
+          type Review @key(fields: "id") {
             id: ID!
-            product: Product @federation__provides(fields: "upc")
+            product: Product @provides(fields: "upc")
           }
         GRAPHQL
       )
@@ -2249,13 +2249,13 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@requires", "@extends", "@key"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
-            price: Int @federation__external
-            shippingEstimate: Int @federation__requires(fields: "price weight")
-            upc: String! @federation__external
-            weight: Int @federation__external
+          type Product @extends @key(fields: "upc") {
+            price: Int @external
+            shippingEstimate: Int @requires(fields: "price weight")
+            upc: String! @external
+            weight: Int @external
           }
         GRAPHQL
       )
@@ -2278,9 +2278,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-            type Product @federation__key(fields: "productId") {
+            type Product @key(fields: "productId") {
               productId: String!
             }
           GRAPHQL
@@ -2306,11 +2306,11 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+              @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@requires", "@extends", "@key"])
 
-            type Product @federation__extends @federation__key(fields: "product_id") {
-              options: [String!]! @federation__requires(fields: "my_id")
-              otherOptions: [String!]! @federation__requires(fields: "myId")
+            type Product @extends @key(fields: "product_id") {
+              options: [String!]! @requires(fields: "my_id")
+              otherOptions: [String!]! @requires(fields: "myId")
               product_id: String!
             }
           GRAPHQL
@@ -2339,10 +2339,10 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@external", "@extends", "@key"])
 
-          type Product @federation__extends @federation__key(fields: "upc") {
-            upc: String! @federation__external
+          type Product @extends @key(fields: "upc") {
+            upc: String! @external
           }
         GRAPHQL
       )
@@ -2367,9 +2367,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key"])
 
-          type Product @federation__key(fields: "id") {
+          type Product @key(fields: "id") {
             id: ID!
           }
         GRAPHQL
@@ -2401,7 +2401,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
           type Product @fed2__extends {
             upc: String!
@@ -2438,7 +2438,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2", import: ["@composeDirective", "@inaccessible", "@policy", "@tag", "@cost", "@listSize"])
+            @link(url: "https://specs.apollo.dev/federation/v2.6", as: "fed2")
 
           type Product @fed2__extends {
             upc: String!


### PR DESCRIPTION
    - Removed deprecated imports for `google-protobuf` in Gemfile.lock.
    - Updated README to clarify SDL generation for Federation v2.
    - Enhanced `FederatedDocumentFromSchemaDefinition` to track used directives.
    - Modified `Schema` methods to support dynamic directive imports based on usage.
    - Updated tests to reflect changes in SDL output for various directives.
    
    This refactor improves the handling of directives in Apollo Federation, ensuring only necessary directives are imported based on the schema's usage.
