### PR TITLE
feat: Enable list size directive registration from resolvers

### DIFF
--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -23,6 +23,30 @@ module ApolloFederation
       super(*args, **kwargs, &block)
     end
 
+    # We expose list_size directive so that it can be used in resolvers
+    def add_list_size_directive(list_size)
+      return unless list_size
+
+      arguments = []
+      if list_size.key?(:assumed_size)
+        arguments << { name: 'assumedSize', values: list_size[:assumed_size] }
+      end
+      if (slicing_args = list_size[:slicing_arguments])
+        arguments << { name: 'slicingArguments', values: slicing_args }
+        if list_size.key?(:require_one_slicing_argument)
+          arguments << {
+            name: 'requireOneSlicingArgument',
+            values: list_size[:require_one_slicing_argument],
+          }
+        end
+      end
+      if list_size[:sized_fields]
+        arguments << { name: 'sizedFields', values: list_size[:sized_fields] }
+      end
+
+      add_directive(name: 'listSize', arguments: arguments) unless arguments.empty?
+    end
+
     private
 
     def add_v1_directives(external: nil, requires: nil, provides: nil, **_kwargs)
@@ -112,28 +136,6 @@ module ApolloFederation
       )
     end
 
-    def add_list_size_directive(list_size)
-      return unless list_size
-
-      arguments = []
-      if list_size.key?(:assumed_size)
-        arguments << { name: 'assumedSize', values: list_size[:assumed_size] }
-      end
-      if (slicing_args = list_size[:slicing_arguments])
-        arguments << { name: 'slicingArguments', values: slicing_args }
-        if list_size.key?(:require_one_slicing_argument)
-          arguments << {
-            name: 'requireOneSlicingArgument',
-            values: list_size[:require_one_slicing_argument],
-          }
-        end
-      end
-      if list_size[:sized_fields]
-        arguments << { name: 'sizedFields', values: list_size[:sized_fields] }
-      end
-
-      add_directive(name: 'listSize', arguments: arguments) unless arguments.empty?
-    end
 
     def add_tag_directive(tag)
       add_directive(

--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -136,7 +136,6 @@ module ApolloFederation
       )
     end
 
-
     def add_tag_directive(tag)
       add_directive(
         name: 'tag',

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -1846,7 +1846,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         class_methods do
           def apply_list_size_directive(field)
-            field.add_list_size_directive({ slicing_arguments: 'limit', require_one_slicing_argument: true })
+            field.add_list_size_directive({ slicing_arguments: ['limit'], require_one_slicing_argument: true })
           end
         end
       end
@@ -1891,7 +1891,7 @@ RSpec.describe ApolloFederation::ServiceField do
               Page number to get, starting at 1.
               """
               page: Int = 1
-            ): [String!]! @listSize(slicingArguments: "limit", requireOneSlicingArgument: true)
+            ): [String!]! @listSize(slicingArguments: ["limit"], requireOneSlicingArgument: true)
           }
         GRAPHQL
       )

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe ApolloFederation::ServiceField do
       
           super(*args, camelize: camelize, **kwargs, &block)
           resolver_class = kwargs[:resolver_class]
-          if resolver_class && resolver_class.respond_to?(:apply_list_size_directive)
-            resolver_class.apply_list_size_directive(self)
-          end
+          
+          return unless resolver_class && resolver_class.respond_to?(:apply_list_size_directive)
+          
+          resolver_class.apply_list_size_directive(self)
         end
       end
 
@@ -1839,13 +1840,13 @@ RSpec.describe ApolloFederation::ServiceField do
         extend ActiveSupport::Concern
     
         included do
-          argument :limit, Integer, "Number of items to get, the default is " + 60.to_s + ".", default_value: 60, required: false
-          argument :page, Integer, "Page number to get, starting at 1.", default_value: 1, required: false
+          argument :limit, Integer, "Number of items to get, the default is #{60}.", default_value: 60, required: false
+          argument :page, Integer, 'Page number to get, starting at 1.', default_value: 1, required: false
         end
     
         class_methods do
           def apply_list_size_directive(field)
-            field.add_list_size_directive({slicing_arguments: 'limit', require_one_slicing_argument: true})
+            field.add_list_size_directive({ slicing_arguments: 'limit', require_one_slicing_argument: true })
           end
         end
       end

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe ApolloFederation::ServiceField do
         def initialize(*args, permission_scope: nil, camelize: true, skip_depth: false, **kwargs, &block)
           @permission_scope = permission_scope
           @skip_depth = skip_depth
-      
+
           super(*args, camelize: camelize, **kwargs, &block)
           resolver_class = kwargs[:resolver_class]
-          
+
           return unless resolver_class.respond_to?(:apply_list_size_directive)
-          
+
           resolver_class.apply_list_size_directive(self)
         end
       end
@@ -1838,12 +1838,12 @@ RSpec.describe ApolloFederation::ServiceField do
     it 'returns valid SDL for @listSize directive added by resolver' do
       module Pagination
         extend ActiveSupport::Concern
-    
+
         included do
           argument :limit, Integer, 'Number of items to get, the default is 60.', default_value: 60, required: false
           argument :page, Integer, 'Page number to get, starting at 1.', default_value: 1, required: false
         end
-    
+
         class_methods do
           def apply_list_size_directive(field)
             field.add_list_size_directive({ slicing_arguments: 'limit', require_one_slicing_argument: true })

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'active_support/concern'
 require 'graphql'
 require 'apollo-federation/schema'
 require 'apollo-federation/field'
@@ -18,6 +19,17 @@ RSpec.describe ApolloFederation::ServiceField do
     let(:base_object) do
       base_field = Class.new(GraphQL::Schema::Field) do
         include ApolloFederation::Field
+
+        def initialize(*args, permission_scope: nil, camelize: false, skip_depth: false, **kwargs, &block)
+          @permission_scope = permission_scope
+          @skip_depth = skip_depth
+      
+          super(*args, camelize: camelize, **kwargs, &block)
+          resolver_class = kwargs[:resolver_class]
+          if resolver_class && resolver_class.respond_to?(:apply_list_size_directive)
+            resolver_class.apply_list_size_directive(self)
+          end
+        end
       end
 
       Class.new(GraphQL::Schema::Object) do
@@ -1817,6 +1829,68 @@ RSpec.describe ApolloFederation::ServiceField do
           type Product @key(fields: "id") {
             id: ID!
             reviews: [String!]! @listSize(assumedSize: 5)
+          }
+        GRAPHQL
+      )
+    end
+
+    it 'returns valid SDL for @listSize directive added by resolver' do
+      module Pagination
+        extend ActiveSupport::Concern
+    
+        included do
+          argument :limit, Integer, "Number of items to get, the default is " + 60.to_s + ".", default_value: 60, required: false
+          argument :page, Integer, "Page number to get, starting at 1.", default_value: 1, required: false
+        end
+    
+        class_methods do
+          def apply_list_size_directive(field)
+            field.add_list_size_directive({slicing_arguments: 'limit', require_one_slicing_argument: true})
+          end
+        end
+      end
+
+      test_resolver = Class.new(GraphQL::Schema::Resolver) do
+        include Pagination
+
+        type [String], null: false
+
+        def resolve
+          ['Great product!', 'Highly recommended', 'Excellent quality']
+        end
+      end
+
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        key fields: :id
+
+        field :id, 'ID', null: false
+        field :reviews, resolver: test_resolver
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types product
+        federation version: '2.9'
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@listSize", "@key"])
+
+          type Product @key(fields: "id") {
+            id: ID!
+            reviews(
+              """
+              Number of items to get, the default is 60.
+              """
+              limit: Int = 60
+
+              """
+              Page number to get, starting at 1.
+              """
+              page: Int = 1
+            ): [String!]! @listSize(slicingArguments: "limit", requireOneSlicingArgument: true)
           }
         GRAPHQL
       )

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ApolloFederation::ServiceField do
           super(*args, camelize: camelize, **kwargs, &block)
           resolver_class = kwargs[:resolver_class]
           
-          return unless resolver_class && resolver_class.respond_to?(:apply_list_size_directive)
+          return unless resolver_class&.respond_to?(:apply_list_size_directive)
           
           resolver_class.apply_list_size_directive(self)
         end
@@ -1840,7 +1840,7 @@ RSpec.describe ApolloFederation::ServiceField do
         extend ActiveSupport::Concern
     
         included do
-          argument :limit, Integer, "Number of items to get, the default is #{60}.", default_value: 60, required: false
+          argument :limit, Integer, "Number of items to get, the default is 60.", default_value: 60, required: false
           argument :page, Integer, 'Page number to get, starting at 1.', default_value: 1, required: false
         end
     

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe ApolloFederation::ServiceField do
       base_field = Class.new(GraphQL::Schema::Field) do
         include ApolloFederation::Field
 
-        def initialize(*args, permission_scope: nil, camelize: false, skip_depth: false, **kwargs, &block)
+        def initialize(*args, permission_scope: nil, camelize: true, skip_depth: false, **kwargs, &block)
           @permission_scope = permission_scope
           @skip_depth = skip_depth
       
           super(*args, camelize: camelize, **kwargs, &block)
           resolver_class = kwargs[:resolver_class]
           
-          return unless resolver_class&.respond_to?(:apply_list_size_directive)
+          return unless resolver_class.respond_to?(:apply_list_size_directive)
           
           resolver_class.apply_list_size_directive(self)
         end
@@ -1840,7 +1840,7 @@ RSpec.describe ApolloFederation::ServiceField do
         extend ActiveSupport::Concern
     
         included do
-          argument :limit, Integer, "Number of items to get, the default is 60.", default_value: 60, required: false
+          argument :limit, Integer, 'Number of items to get, the default is 60.', default_value: 60, required: false
           argument :page, Integer, 'Page number to get, starting at 1.', default_value: 1, required: false
         end
     


### PR DESCRIPTION
- Exposed add_list_size_directive so that resolvers can call it
- Written unit test to make sure schema is generated correctly when resolvers add list_size directive