### PR TITLE
feat: revert GEM_HOST_API_KEY secret name for semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,4 +172,4 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
## Problem

The semantic-release CI job was failing with the error:
```
SemanticReleaseError: No gem API key specified.
```

This error occurred after commit `874e497` when the CI workflow was updated.

## Root Cause

The `semantic-release-rubygem` plugin expects the gem API key to be in the `GEM_HOST_API_KEY` environment variable. The workflow was updated to reference `secrets.RUBYGEMS_API_KEY` instead of `secrets.GEM_HOST_API_KEY`, but this secret doesn't exist in the repository.

## Solution

This PR reverts the secret name from `RUBYGEMS_API_KEY` back to `GEM_HOST_API_KEY` to restore the working configuration from commit `6c86b04`.

## Changes

- Reverted `.github/workflows/ci.yml` to use `secrets.GEM_HOST_API_KEY` instead of `secrets.RUBYGEMS_API_KEY`

## Testing

This configuration was previously working successfully in commit `6c86b04` which triggered release `585399a`.